### PR TITLE
Add link association to android

### DIFF
--- a/frontend/.well-known/assetlinks.json
+++ b/frontend/.well-known/assetlinks.json
@@ -1,0 +1,30 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.flipperdevices.app",
+      "sha256_cert_fingerprints": [
+        "54:17:E7:A2:2C:5F:96:A0:14:D8:F3:C4:E6:5B:54:DA:70:50:93:15:11:10:BA:CA:45:86:E2:56:89:68:93:1E",
+        "3F:8F:3C:D7:B1:F9:98:5D:2C:B0:9B:83:C5:AA:DF:F7:A2:CF:B4:B3:B7:5E:03:60:0D:70:24:06:23:52:01:FC",
+        "FA:55:8E:0B:11:A8:F9:FD:47:30:28:90:78:E7:3C:94:DD:9C:26:CD:DB:A9:66:53:65:79:2B:35:C0:0C:1B:E8"
+      ]
+    }
+  },
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.flipperdevices.app.dev",
+      "sha256_cert_fingerprints": [
+        "54:17:E7:A2:2C:5F:96:A0:14:D8:F3:C4:E6:5B:54:DA:70:50:93:15:11:10:BA:CA:45:86:E2:56:89:68:93:1E",
+        "3F:8F:3C:D7:B1:F9:98:5D:2C:B0:9B:83:C5:AA:DF:F7:A2:CF:B4:B3:B7:5E:03:60:0D:70:24:06:23:52:01:FC",
+        "FA:55:8E:0B:11:A8:F9:FD:47:30:28:90:78:E7:3C:94:DD:9C:26:CD:DB:A9:66:53:65:79:2B:35:C0:0C:1B:E8"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
For two app packages: `com.flipperdevices.app` (internal and prod) and `com.flipperdevices.app.dev` (debug)

And for three fingerprints:
- Debug key for development (my PC): `54:17:E7:A2:2C:5F:96:A0:14:D8:F3:C4:E6:5B:54:DA:70:50:93:15:11:10:BA:CA:45:86:E2:56:89:68:93:1E`
- Google Play sign: `3F:8F:3C:D7:B1:F9:98:5D:2C:B0:9B:83:C5:AA:DF:F7:A2:CF:B4:B3:B7:5E:03:60:0D:70:24:06:23:52:01:FC`
- Our production sign: `FA:55:8E:0B:11:A8:F9:FD:47:30:28:90:78:E7:3C:94:DD:9C:26:CD:DB:A9:66:53:65:79:2B:35:C0:0C:1B:E8`