### PR TITLE
Open deep link on dev android app

### DIFF
--- a/frontend/s/index.html
+++ b/frontend/s/index.html
@@ -267,7 +267,7 @@
           const playLink = storelinks.android + '&url=' + keyUrlEncoded
           const playLinkEncoded = encodeURIComponent(playLink)
           
-          const url = 'intent:open?' + keyUrlEncoded + '#Intent;S.browser_fallback_url=' + playLinkEncoded + ';scheme=flipperkey;package=com.flipperdevices.app;action=android.intent.action.VIEW;B.branch_intent=true;end;'
+          const url = 'intent:open?' + keyUrlEncoded + '#Intent;S.browser_fallback_url=' + playLinkEncoded + ';scheme=flipperkey;package=com.flipperdevices.app;package=com.flipperdevices.app.dev;action=android.intent.action.VIEW;B.branch_intent=true;end;'
           document.querySelector('#open').href = url
         } else {
           document.querySelector('#open').innerText = 'Download'


### PR DESCRIPTION
**Background**

On local/dev testing we can't redirect to app.dev after click on deeplink

**Changes**

Add new package `com.flipperdevices.app.dev`
```
Intent checks first package - `com.flipperdevices.app`
Intent checks second package - `com.flipperdevices.app.dev`
If not ready two package we going to Play Market with deep link
```

**Test plan**

Build local application and try going to some deep link
