### PR TITLE
fix: use `encodeURIComponent` to keep new lines

### DIFF
--- a/frontend/s/index.html
+++ b/frontend/s/index.html
@@ -271,7 +271,7 @@
         } else {
           document.querySelector('#open').innerText = 'Download'
           document.querySelector('#open').download = params.name + '.' + params.extension
-          document.querySelector('#open').href = 'data:application/octet-stream,' + fileString
+          document.querySelector('#open').href = 'data:application/octet-stream,' + encodeURIComponent(fileString)
         }
       }
     </script>


### PR DESCRIPTION
When clicking Download, files were downloaded without new lines.
(Tested on Windows with Edge, macOS with Safari and Firefox)

For example, a file looked like this:
```
Filetype: IR signals fileVersion: 1name: Fan_speedtype: rawfrequency: 38000duty_cycle: 0.330000data: ...
```

After adding `encodeURIComponent` the file is downloaded like expected:
```
Filetype: IR signals file
Version: 1
name: Fan_speed
type: raw
frequency: 38000
duty_cycle: 0.330000
data: ...
```