### PR TITLE
Remove dev package from android deeplink

### DIFF
--- a/frontend/sf/index.html
+++ b/frontend/sf/index.html
@@ -267,7 +267,7 @@
           const playLink = storelinks.android + '&url=' + keyUrlEncoded
           const playLinkEncoded = encodeURIComponent(playLink)
           
-          const url = 'intent:open?' + keyUrlEncoded + '#Intent;S.browser_fallback_url=' + playLinkEncoded + ';scheme=flipperkey;package=com.flipperdevices.app;package=com.flipperdevices.app.dev;action=android.intent.action.VIEW;B.branch_intent=true;end;'
+          const url = 'intent:open?' + keyUrlEncoded + '#Intent;S.browser_fallback_url=' + playLinkEncoded + ';scheme=flipperkey;package=com.flipperdevices.app;action=android.intent.action.VIEW;B.branch_intent=true;end;'
           document.querySelector('#open').href = url
         } else {
           fetch(`https://transfer.flpr.app/${params.id}/hakuna-matata`)


### PR DESCRIPTION
Right now we fail when try open deep link in /sf link on Android in Google Play

Current fix remove `dev` prefix