### PR TITLE
Fix unknown file types not loading

### DIFF
--- a/frontend/sf/index.html
+++ b/frontend/sf/index.html
@@ -242,7 +242,7 @@
             break
           default:
             badgeText = 'Unknown'
-            document.querySelector('#type').style.display = 'none'
+            document.querySelector('#badge').style.display = 'none'
         }
 
         document.querySelector('#badge').classList.add(params.extension)


### PR DESCRIPTION
unknown file types would work fine, but they reach this code which returns undefined, i assume its supposed to hide the file type badge